### PR TITLE
chore: add custom error type for http calls

### DIFF
--- a/internal/api/impl.go
+++ b/internal/api/impl.go
@@ -3,12 +3,29 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"net/http"
 	//"path"
 
 	"artifact-store/internal/storage"
+	"artifact-store/internal/storage/storage_error"
 )
+
+type ArtifactErrorMessage interface {
+	ResourceNotFound(resource string, version string)
+	InternalServerError(resource string, version string)
+}
+
+type ArtifactError struct {
+	ErrorMessage string
+}
+
+func (e* ArtifactError) ResourceNotFound(resource string, version string) {
+	e.ErrorMessage = fmt.Sprintf("The requested resource '%v:%v' was not found", resource, version)
+}
+
+func (e* ArtifactError) InternalServerError(resource string, version string) {
+	e.ErrorMessage = fmt.Sprintf("Internal server error occurred while fetching the requested resource '%v:%v'", resource, version)
+}
 
 type Server struct{
 	storageHandler storage.Storage
@@ -30,19 +47,25 @@ func (s Server) GetCharts(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(data)
 }
 
-func (s Server) GetChart(w http.ResponseWriter, r *http.Request, name string, version string) {
-	data, err := s.storageHandler.Read(name, version)
+func (s Server) GetChart(w http.ResponseWriter, r *http.Request, resource string, version string) {
+	data, err := s.storageHandler.Read(resource, version)
 	if err != nil {
-		if err == fs.ErrNotExist { // TODO: map to generic error types in case other backends are used
+		e := &ArtifactError{}
+		if err == storage_error.NotFound {
+			e.ResourceNotFound(resource, version)
 			w.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(w).Encode(err) // TODO: define error type
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(e)
 			return
 		}
+		e.InternalServerError(resource, version)
 		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(err) // TODO: define error type
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(e)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(data)
 }
 

--- a/internal/storage/backend/fs.go
+++ b/internal/storage/backend/fs.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+
+	"artifact-store/internal/storage/storage_error"
 )
 
 type FileSystem struct {
@@ -30,23 +32,23 @@ func (f *FileSystem) Write(bytes []byte) error { // TODO: define type `artifact`
 func (f *FileSystem) Read(resource string, version string) ([]byte, error) {
 	dir, err := f.Path.Open(filepath.Join(resource, version))
 	if err != nil {
-		return nil, err
+		return nil, storage_error.IOError
 	}
 	if rd, ok := dir.(fs.ReadDirFile); ok {
 		entries, err := rd.ReadDir(-1)
 		if err != nil {
 			dir.Close()
-			return nil, err
+			return nil, storage_error.IOError
 		}
 		if len(entries) == 0 {
 			dir.Close()
-			return nil, fs.ErrNotExist
+			return nil, storage_error.NotFound
 		}
 		file := path.Join(resource, version, entries[0].Name())
 		dir.Close()
 		fileBytes, err := fs.ReadFile(f.Path, path.Clean(file))
 		if err != nil {
-			return nil, err
+			return nil, storage_error.IOError
 		}
 		return fileBytes, nil
 	}

--- a/internal/storage/storage_error/error.go
+++ b/internal/storage/storage_error/error.go
@@ -1,0 +1,8 @@
+package storage_error
+
+import (
+	"errors"
+)
+
+var NotFound = errors.New("resource not found")
+var IOError = errors.New("IO error on resource read/write")


### PR DESCRIPTION
Best practice is certainly not to return debug information to users, so this PR adds a starting point for custom error types when making HTTP calls